### PR TITLE
Catch nil values for performance from Controllr API

### DIFF
--- a/app/models/controllr.rb
+++ b/app/models/controllr.rb
@@ -32,7 +32,7 @@ class Controllr
       total: data_totals['monthly_total_hours'].to_f
     }
 
-    performance = data['calculations']['performance'].round(2)
+    performance = data['calculations']['performance'].to_f.round(2)
 
     {
       hours: hours,


### PR DESCRIPTION
Fixes https://sentry.panter.biz/panter/apipanterch/issues/5862/

The accounting data only goes back to October 2012, on requests for older months [no performance is returned](https://git.panter.ch/panter/controllr/blob/master/app/controllers/api/monthly_salaries_controller.rb).