### PR TITLE
remove obsolete application job

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,2 +1,0 @@
-class ApplicationJob < ActiveJob::Base
-end


### PR DESCRIPTION
b6655fe3fda447c5e2ff7af8d227d580c61ee18c uncommented the unused rails
feature, while leaving the ApplicationJob in place.